### PR TITLE
Rename scope to playlist-modify-public

### DIFF
--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -40,7 +40,7 @@ class SessionTest extends PHPUnit_Framework_TestCase
     {
         $clientID = getenv('SPOTIFY_CLIENT_ID');
         $redirectUri = urlencode(getenv('SPOTIFY_REDIRECT_URI'));
-        $scope = array('user-read-email', 'playlist-modify');
+        $scope = array('user-read-email', 'playlist-modify-public');
         $scopeOut = urlencode(implode(' ', $scope));
 
         $expected = "https://accounts.spotify.com/authorize/?client_id=$clientID&redirect_uri=$redirectUri&response_type=code&scope=$scopeOut&show_dialog=false&state=";
@@ -128,7 +128,7 @@ class SessionTest extends PHPUnit_Framework_TestCase
     {
         $clientID = getenv('SPOTIFY_CLIENT_ID');
         $redirectUri = urlencode(getenv('SPOTIFY_REDIRECT_URI'));
-        $scope = array('user-read-email', 'playlist-modify');
+        $scope = array('user-read-email', 'playlist-modify-public');
         $scopeOut = urlencode(implode(' ', $scope));
         $state = 'foobar';
 


### PR DESCRIPTION
Spotify's Web API has renamed the `playlist-modify` scope to `playlist-modify-public` to better describe what it allows. Even though the old one will be supported for some time, the new one is the preferred way to go.
