### PR TITLE
Added option to set return type to assoc array

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -3,6 +3,8 @@ namespace SpotifyWebAPI;
 
 class Request
 {
+    private $returnAssoc = false;
+
     const ACCOUNT_URL = 'https://accounts.spotify.com';
     const API_URL = 'https://api.spotify.com';
 
@@ -105,10 +107,10 @@ class Request
 
         list($headers, $body) = explode("\r\n\r\n", $response, 2);
 
-        $body = json_decode($body);
+        $body = json_decode($body, $this->returnAssoc);
 
         if ($status < 200 || $status > 299) {
-            if (isset($body->error)) {
+            if (!$this->returnAssoc && isset($body->error)) {
                 $error = $body->error;
 
                 // These properties only exist on API calls, not auth calls
@@ -116,6 +118,17 @@ class Request
                     throw new SpotifyWebAPIException($error->message, $error->status);
                 } elseif (isset($body->error_description)) {
                     throw new SpotifyWebAPIException($body->error_description, $status);
+                } else {
+                    throw new SpotifyWebAPIException($error, $status);
+                }
+            } elseif ($this->returnAssoc && isset($body['error'])) {
+                $error = $body['error'];
+
+                // These properties only exist on API calls, not auth calls
+                if (isset($error['message']) && isset($error['status'])) {
+                    throw new SpotifyWebAPIException($error['message'], $error['status']);
+                } elseif (isset($body['error_description'])) {
+                    throw new SpotifyWebAPIException($body['error_description'], $status);
                 } else {
                     throw new SpotifyWebAPIException($error, $status);
                 }
@@ -129,5 +142,31 @@ class Request
             'headers' => $headers,
             'status' => $status
         );
+    }
+
+    /**
+     * Set the return type for the body element
+     * If unset or set to false it will return a stdObject, but
+     * if set to true it will return an associative array.
+     *
+     * @param bool $returnAssoc Whether to return an associative array or not.
+     *
+     * @return void
+     */
+    public function setReturnAssoc($returnAssoc)
+    {
+        $this->returnAssoc = $returnAssoc;
+    }
+
+    /**
+     * Returns true if this class returns the body as an
+     * associative array, and false if it returns the body
+     * as a stdObject.
+     *
+     * @return bool true if body is returned as an array, else false.
+     */
+    public function getReturnAssoc()
+    {
+        return $this->returnAssoc;
     }
 }

--- a/src/SpotifyWebAPI.php
+++ b/src/SpotifyWebAPI.php
@@ -714,4 +714,30 @@ class SpotifyWebAPI
 
         return $response['status'] == 200;
     }
+
+    /**
+     * Set the return type for the Request body element
+     * If unset or set to false it will return a stdObject, but
+     * if set to true it will return an associative array.
+     *
+     * @param bool $returnAssoc Whether to return an associative array or not.
+     *
+     * @return void
+     */
+    public function setReturnAssoc($returnAssoc)
+    {
+        $this->request->setReturnAssoc($returnAssoc);
+    }
+
+    /**
+     * Get the return type for the Request body element
+     * Returns true if the body is returned as an associative array,
+     * and false if it is returned as an stdObject.
+     *
+     * @return bool true if body is returned as an array, else false.
+     */
+    public function getReturnAssoc()
+    {
+        return $this->request->getReturnAssoc();
+    }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -64,4 +64,25 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
         $response = $this->request->send('GET', 'https://api.spotify.com/v1/albums/NON_EXISTING_ALBUM');
     }
+
+    public function testSetReturnAssoc()
+    {
+        $request = new SpotifyWebAPI\Request();
+        $this->assertFalse($request->getReturnAssoc());
+
+        $request->setReturnAssoc(true);
+        $this->assertTrue($request->getReturnAssoc());
+
+        $request->setReturnAssoc(false);
+        $this->assertFalse($request->getReturnAssoc());
+    }
+
+    public function testSendReturnAssoc()
+    {
+        $request = new SpotifyWebAPI\Request();
+        $request->setReturnAssoc(true);
+
+        $response = $request->send('GET', 'https://api.spotify.com/v1/albums/7u6zL7kqpgLPISZYXNTgYk');
+        $this->assertArrayHasKey('id', $response['body']);
+    }
 }

--- a/tests/SpotifyWebAPITest.php
+++ b/tests/SpotifyWebAPITest.php
@@ -367,4 +367,24 @@ class SpotifyWebAPITest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($response);
     }
+
+    public function testSetReturnAssoc()
+    {
+        $request = $this->getMock('SpotifyWebAPI\Request');
+        $request->expects($this->once())->method('setReturnAssoc')->with(true);
+
+        $api = new SpotifyWebAPI\SpotifyWebAPI($request);
+        $api->setReturnAssoc(true);
+    }
+
+    public function testGetReturnAssoc()
+    {
+        $request = $this->getMock('SpotifyWebAPI\Request');
+        $request->expects($this->once())
+            ->method('getReturnAssoc')
+            ->willReturn(true);
+
+        $api = new SpotifyWebAPI\SpotifyWebAPI($request);
+        $this->assertTrue($api->getReturnAssoc(true));
+    }
 }


### PR DESCRIPTION
In order to make it possible to retrieve an associative array as the response from the web API we needed to add this functionality. I'm not sure if there is a better way to do this, but this seems to work fine for us.

The option to retrieve an array is much cleaner than writing a recursive wrapper that tranforms the stdObject to an array.
