### PR TITLE
Renamed refreshToken() and requestToken() to more descriptive names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This is a PHP implementation of the [Spotify Web API](https://developer.spotify.com/web-api/). It includes the following:
 
-* Helper methods for all API methods (Information about artists, albums and tracks).
+* Helper methods for all API methods (information about artists, albums and tracks).
 * Search the Spotify catalog.
 * Get information about users and their music library.
 * Manage playlists for users.
@@ -170,7 +170,7 @@ $user = $api->getUser('username');
 print_r($user);
 ```
 
-Get a user's playlists
+Get user's playlists
 
 ```php
 $playlists = $api->getUserPlaylists('username');
@@ -266,7 +266,7 @@ Update a user's playlist
 $api->updateUserPlaylist('username', 'playlist_id', array('name' => 'New name'));
 ```
 
-Follow/Unfollow artist or user
+Follow and unfollow an artist or user
 
 ```php
 
@@ -281,7 +281,7 @@ $api->followArtistsOrUsers('user',array('spotify','spotify_france'));
 $api->unfollowArtistsOrUsers('user',array('spotify','spotify_france'));
 ```
 
-Check if current user follows artist or user
+Check if current user follows an artist or user
 
 ```php
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,6 @@ $api->updateUserPlaylist('username', 'playlist_id', array('name' => 'New name'))
 Follow and unfollow an artist or user
 
 ```php
-
 $api->followArtistsOrUsers('artist','74ASZWbe4lXaubB36ztrGX');
 
 $api->unfollowArtistsOrUsers('artist','74ASZWbe4lXaubB36ztrGX');
@@ -284,7 +283,6 @@ $api->unfollowArtistsOrUsers('user',array('spotify','spotify_france'));
 Check if current user follows an artist or user
 
 ```php
-
 $follows = $api->currentUserFollows('user',
     'spotify,spotify_france'
 );
@@ -295,7 +293,6 @@ $follows = $api->currentUserFollows('artist','74ASZWbe4lXaubB36ztrGX');
 
 var_dump($follows);
 ```
-
 
 Browse through `src/SpotifyWebAPI.php` and look at the tests for more methods and examples.
 

--- a/demo.php
+++ b/demo.php
@@ -6,11 +6,15 @@ require 'vendor/autoload.php';
 
 Dotenv::load(__DIR__);
 
-$session = new SpotifyWebAPI\Session(getenv('SPOTIFY_CLIENT_ID'), getenv('SPOTIFY_CLIENT_SECRET'), getenv('SPOTIFY_REDIRECT_URI'));
+$session = new SpotifyWebAPI\Session(
+    getenv('SPOTIFY_CLIENT_ID'),
+    getenv('SPOTIFY_CLIENT_SECRET'),
+    getenv('SPOTIFY_REDIRECT_URI')
+);
 $api = new SpotifyWebAPI\SpotifyWebAPI();
 
 if (isset($_GET['code'])) {
-    $session->requestToken($_GET['code']);
+    $session->requestRefreshAndAccessToken($_GET['code']);
     $api->setAccessToken($session->getAccessToken());
 
     print_r($api->me());

--- a/demo.php
+++ b/demo.php
@@ -14,7 +14,7 @@ $session = new SpotifyWebAPI\Session(
 $api = new SpotifyWebAPI\SpotifyWebAPI();
 
 if (isset($_GET['code'])) {
-    $session->requestRefreshAndAccessToken($_GET['code']);
+    $session->requestAccessToken($_GET['code']);
     $api->setAccessToken($session->getAccessToken());
 
     print_r($api->me());

--- a/src/Request.php
+++ b/src/Request.php
@@ -159,7 +159,7 @@ class Request
         return array(
             'body' => $body,
             'headers' => $headers,
-            'status' => $status
+            'status' => $status,
         );
     }
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -51,7 +51,7 @@ class Session
         $defaults = array(
             'scope' => array(),
             'show_dialog' => false,
-            'state' => ''
+            'state' => '',
         );
 
         $options = array_merge($defaults, (array) $options);
@@ -61,7 +61,7 @@ class Session
             'response_type' => 'code',
             'scope' => implode(' ', $options['scope']),
             'show_dialog' => $options['show_dialog'] ? 'true' : 'false',
-            'state' => $options['state']
+            'state' => $options['state'],
         );
 
         return Request::ACCOUNT_URL . '/authorize/?' . http_build_query($parameters);
@@ -128,21 +128,29 @@ class Session
     }
 
     /**
-     * Refresh a access token.
+     * @deprecated Use Session::refreshAccessToken instead. This dummy function will be removed in 1.0.0.
+     */
+    public function refreshToken()
+    {
+        trigger_error('Use Session::refreshAccessToken instead', E_USER_DEPRECATED);
+    }
+
+    /**
+     * Refresh an access token.
      *
      * @return bool Whether the access token was successfully refreshed.
      */
-    public function refreshToken()
+    public function refreshAccessToken()
     {
         $payload = base64_encode($this->getClientId() . ':' . $this->getClientSecret());
 
         $parameters = array(
             'grant_type' => 'refresh_token',
-            'refresh_token' => $this->refreshToken
+            'refresh_token' => $this->refreshToken,
         );
 
         $headers = array(
-            'Authorization' => 'Basic ' . $payload
+            'Authorization' => 'Basic ' . $payload,
         );
 
         $response = $this->request->account('POST', '/api/token', $parameters, $headers);
@@ -171,11 +179,11 @@ class Session
 
         $parameters = array(
             'grant_type' => 'client_credentials',
-            'scope' => implode(' ', $scope)
+            'scope' => implode(' ', $scope),
         );
 
         $headers = array(
-            'Authorization' => 'Basic ' . $payload
+            'Authorization' => 'Basic ' . $payload,
         );
 
         $response = $this->request->account('POST', '/api/token', $parameters, $headers);
@@ -192,29 +200,38 @@ class Session
     }
 
     /**
-     * Request a access token.
+     * @deprecated Use Session::requestRefreshAndAccessToken instead. This dummy function will be removed in 1.0.0.
+     */
+    public function requestToken($code)
+    {
+        trigger_error('Use Session::requestRefreshAndAccessToken instead', E_USER_DEPRECATED);
+    }
+
+    /**
+     * Request a refresh and access token.
      *
      * @param string $code The authorization code from Spotify.
      *
-     * @return bool Whether a access token was successfully granted.
+     * @return bool Whether both the refresh and access tokens were successfully granted.
      */
-    public function requestToken($code)
+    public function requestRefreshAndAccessToken($code)
     {
         $parameters = array(
             'client_id' => $this->getClientId(),
             'client_secret' => $this->getClientSecret(),
             'code' => $code,
             'grant_type' => 'authorization_code',
-            'redirect_uri' => $this->getRedirectUri()
+            'redirect_uri' => $this->getRedirectUri(),
         );
 
         $response = $this->request->account('POST', '/api/token', $parameters);
         $response = $response['body'];
 
-        if (isset($response->access_token)) {
+        if (isset($response->refresh_token)
+                && isset($response->access_token)) {
+            $this->refreshToken = $response->refresh_token;
             $this->accessToken = $response->access_token;
             $this->expires = $response->expires_in;
-            $this->refreshToken = $response->refresh_token;
 
             return true;
         }

--- a/src/Session.php
+++ b/src/Session.php
@@ -98,9 +98,9 @@ class Session
     }
 
     /**
-     * Get the number of seconds before the access token expires.
+     * Get the number of seconds for which the access token is valid.
      *
-     * @return int The expires time.
+     * @return int The time period (in seconds) for which the access token is valid.
      */
     public function getExpires()
     {
@@ -171,7 +171,7 @@ class Session
      *
      * @param array $scope Optional. Scope(s) to request from the user.
      *
-     * @return bool Whether a access token was successfully granted.
+     * @return bool True whether an access token was successfully granted, false otherwise.
      */
     public function requestCredentialsToken($scope = array())
     {
@@ -210,11 +210,11 @@ class Session
     /**
      * Request a refresh and access token.
      *
-     * @param string $code The authorization code from Spotify.
+     * @param string $authorizationCode The authorization code from Spotify.
      *
      * @return bool Whether both the refresh and access tokens were successfully granted.
      */
-    public function requestRefreshAndAccessToken($code)
+    public function requestRefreshAndAccessToken($authorizationCode)
     {
         $parameters = array(
             'client_id' => $this->getClientId(),

--- a/src/Session.php
+++ b/src/Session.php
@@ -133,6 +133,7 @@ class Session
     public function refreshToken()
     {
         trigger_error('Use Session::refreshAccessToken instead', E_USER_DEPRECATED);
+        return $this->refreshAccessToken();
     }
 
     /**
@@ -167,11 +168,11 @@ class Session
     }
 
     /**
-     * Request a access token using the Client Credentials Flow.
+     * Request an access token using the Client Credentials Flow.
      *
      * @param array $scope Optional. Scope(s) to request from the user.
      *
-     * @return bool True whether an access token was successfully granted, false otherwise.
+     * @return bool True when an access token was successfully granted, false otherwise.
      */
     public function requestCredentialsToken($scope = array())
     {
@@ -200,21 +201,22 @@ class Session
     }
 
     /**
-     * @deprecated Use Session::requestRefreshAndAccessToken instead. This dummy function will be removed in 1.0.0.
+     * @deprecated Use Session::requestAccessToken instead. This dummy function will be removed in 1.0.0.
      */
     public function requestToken($code)
     {
-        trigger_error('Use Session::requestRefreshAndAccessToken instead', E_USER_DEPRECATED);
+        trigger_error('Use Session::requestAccessToken instead', E_USER_DEPRECATED);
+        return $this->requestAccessToken($code);
     }
 
     /**
-     * Request a refresh and access token.
+     * Request an access token given an authorization code.
      *
      * @param string $authorizationCode The authorization code from Spotify.
      *
-     * @return bool Whether both the refresh and access tokens were successfully granted.
+     * @return bool True when the access token was successfully granted, false otherwise.
      */
-    public function requestRefreshAndAccessToken($authorizationCode)
+    public function requestAccessToken($authorizationCode)
     {
         $parameters = array(
             'client_id' => $this->getClientId(),

--- a/src/Session.php
+++ b/src/Session.php
@@ -219,7 +219,7 @@ class Session
         $parameters = array(
             'client_id' => $this->getClientId(),
             'client_secret' => $this->getClientSecret(),
-            'code' => $code,
+            'code' => $authorizationCode,
             'grant_type' => 'authorization_code',
             'redirect_uri' => $this->getRedirectUri(),
         );

--- a/src/SpotifyWebAPI.php
+++ b/src/SpotifyWebAPI.php
@@ -98,7 +98,7 @@ class SpotifyWebAPI
     public function addUserPlaylistTracks($userId, $playlistId, $tracks, $options = array())
     {
         $defaults = array(
-            'position' => false
+            'position' => false,
         );
 
         $options = array_merge($defaults, (array) $options);
@@ -135,8 +135,8 @@ class SpotifyWebAPI
     public function createUserPlaylist($userId, $data)
     {
         $defaults = array(
-            'name' =>  '',
-            'public' => true
+            'name' => '',
+            'public' => true,
         );
 
         $data = array_merge($defaults, (array) $data);
@@ -239,7 +239,9 @@ class SpotifyWebAPI
     public function getAlbums($albumIds)
     {
         $albumIds = implode(',', $albumIds);
-        $options = array('ids' => $albumIds);
+        $options = array(
+            'ids' => $albumIds,
+        );
         $headers = $this->authHeaders();
 
         $response = $this->request->api('GET', '/v1/albums/', $options, $headers);
@@ -262,7 +264,7 @@ class SpotifyWebAPI
     {
         $defaults = array(
             'limit' => 0,
-            'offset' => 0
+            'offset' => 0,
         );
 
         $options = array_merge($defaults, (array) $options);
@@ -301,7 +303,9 @@ class SpotifyWebAPI
     public function getArtists($artistIds)
     {
         $artistIds = implode(',', $artistIds);
-        $options = array('ids' => $artistIds);
+        $options = array(
+            'ids' => $artistIds,
+        );
         $headers = $this->authHeaders();
 
         $response = $this->request->api('GET', '/v1/artists/', $options, $headers);
@@ -344,7 +348,7 @@ class SpotifyWebAPI
             'album_type' => array(),
             'market' => '',
             'limit' => 0,
-            'offset' => 0
+            'offset' => 0,
         );
 
         $options = array_merge($defaults, (array) $options);
@@ -368,7 +372,9 @@ class SpotifyWebAPI
      */
     public function getArtistTopTracks($artistId, $country)
     {
-        $options = array('country' =>  $country);
+        $options = array(
+            'country' => $country,
+        );
         $headers = $this->authHeaders();
 
         $response = $this->request->api('GET', '/v1/artists/' . $artistId . '/top-tracks', $options, $headers);
@@ -397,7 +403,7 @@ class SpotifyWebAPI
             'limit' => 0,
             'locale' => '',
             'offset' => 0,
-            'timestamp' => ''
+            'timestamp' => '',
         );
 
         $options = array_merge($defaults, (array) $options);
@@ -426,7 +432,7 @@ class SpotifyWebAPI
         $defaults = array(
             'country' => '',
             'limit' => 0,
-            'offset' => 0
+            'offset' => 0,
         );
 
         $options = array_merge($defaults, (array) $options);
@@ -453,7 +459,7 @@ class SpotifyWebAPI
     {
         $defaults = array(
             'limit' => 0,
-            'offset' => 0
+            'offset' => 0,
         );
 
         $options = array_merge($defaults, (array) $options);
@@ -502,7 +508,9 @@ class SpotifyWebAPI
     public function getTracks($trackIds)
     {
         $trackIds = implode(',', $trackIds);
-        $options = array('ids' => $trackIds);
+        $options = array(
+            'ids' => $trackIds,
+        );
         $headers = $this->authHeaders();
 
         $response = $this->request->api('GET', '/v1/tracks/', $options, $headers);
@@ -542,7 +550,7 @@ class SpotifyWebAPI
     {
         $defaults = array(
             'limit' => 0,
-            'offset' => 0
+            'offset' => 0,
         );
 
         $options = array_merge($defaults, (array) $options);
@@ -569,7 +577,7 @@ class SpotifyWebAPI
     public function getUserPlaylist($userId, $playlistId, $options = array())
     {
         $defaults = array(
-            'fields' => array()
+            'fields' => array(),
         );
 
         $options = array_merge($defaults, (array) $options);
@@ -601,7 +609,7 @@ class SpotifyWebAPI
         $defaults = array(
             'fields' => array(),
             'limit' => 0,
-            'offset' => 0
+            'offset' => 0,
         );
 
         $options = array_merge($defaults, (array) $options);
@@ -641,7 +649,9 @@ class SpotifyWebAPI
     public function myTracksContains($tracks)
     {
         $tracks = implode(',', (array) $tracks);
-        $options = array('ids' => $tracks);
+        $options = array(
+            'ids' => $tracks,
+        );
         $headers = $this->authHeaders();
 
         $response = $this->request->api('GET', '/v1/me/tracks/contains', $options, $headers);
@@ -663,7 +673,9 @@ class SpotifyWebAPI
     public function replacePlaylistTracks($userId, $playlistId, $tracks)
     {
         $tracks = $this->idToUri($tracks);
-        $tracks = array('uris' => (array) $tracks);
+        $tracks = array(
+            'uris' => (array) $tracks,
+        );
         $tracks = json_encode($tracks);
 
         $headers = $this->authHeaders();
@@ -693,16 +705,16 @@ class SpotifyWebAPI
         $defaults = array(
             'limit' => 0,
             'market' => '',
-            'offset' => 0
+            'offset' => 0,
         );
 
         $type = implode(',', (array) $type);
 
         $options = array_merge($defaults, (array) $options);
         $options = array_filter($options);
-        $options =  array_merge($options, array(
+        $options = array_merge($options, array(
             'query' => $query,
-            'type' => $type
+            'type' => $type,
         ));
 
         $headers = $this->authHeaders();
@@ -737,8 +749,8 @@ class SpotifyWebAPI
     public function updateUserPlaylist($userId, $playlistId, $data)
     {
         $defaults = array(
-            'name' =>  '',
-            'public' => true
+            'name' => '',
+            'public' => true,
         );
 
         $data = array_merge($defaults, (array) $data);
@@ -767,8 +779,9 @@ class SpotifyWebAPI
     {
         $ids = implode(',', (array) $ids);
         $options = array(
-        	'ids' => $ids,
-        	'type' => $type);
+            'ids' => $ids,
+            'type' => $type,
+        );
         $headers = $this->authHeaders();
 
         $response = $this->request->api('GET', '/v1/me/following/contains', $options, $headers);
@@ -784,11 +797,13 @@ class SpotifyWebAPI
      * @param string The ID type: either 'artist' or 'user'.
      * @param string|array ID(s) of the user(s) or artist(s) to follow.
      *
-     * @return bool Whether it worked or not.
+     * @return bool True when all went well, false otherwise.
      */
     public function followArtistsOrUsers($type, $ids)
     {
-        $ids = array('ids' => (array) $ids);
+        $ids = array(
+            'ids' => (array) $ids,
+        );
         $ids = json_encode($ids);
 
         $headers = $this->authHeaders();
@@ -810,11 +825,13 @@ class SpotifyWebAPI
      * @param string The ID type: either 'artist' or 'user'.
      * @param string|array ID(s) of the user(s) or artist(s) to unfollow.
      *
-     * @return bool Whether it worked or not.
+     * @return bool True when all went well, false otherwise.
      */
     public function unfollowArtistsOrUsers($type, $ids)
     {
-        $ids = array('ids' => (array) $ids);
+        $ids = array(
+            'ids' => (array) $ids,
+        );
         $ids = json_encode($ids);
 
         $headers = $this->authHeaders();

--- a/src/SpotifyWebAPIException.php
+++ b/src/SpotifyWebAPIException.php
@@ -3,5 +3,5 @@ namespace SpotifyWebAPI;
 
 class SpotifyWebAPIException extends \Exception
 {
-
+    // dummy
 }


### PR DESCRIPTION
Renamed refreshToken() and requestToken() to more descriptive names
- Session::refreshToken() -> Session::refreshAccessToken()
- Session::requestToken() -> Session::requestRefreshAndAccessToken()
- Besides, added E_USER_DEPRECATED errors to both old methods

Updated the demo + docs accordingly
Fixed some CS