### PR TITLE
Fix: Trying to get property of non-object in Request.php line 163

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -160,7 +160,7 @@ class Request
 
         if ($status < 200 || $status > 299) {
             $errorBody = json_decode($rawBody);
-            $error = $errorBody->error;
+            $error = (isset($errorBody->error)) ? $errorBody->error : null;
 
             if (isset($error->message) && isset($error->status)) {
                 // API call error


### PR DESCRIPTION
Getting an empty 403 Forbidden response when you don’t have correct
oauth scopes set on certain calls which currently aren’t handled.