### PR TITLE
Fix undefined offset 0

### DIFF
--- a/src/SpotifyWebAPI.php
+++ b/src/SpotifyWebAPI.php
@@ -43,7 +43,7 @@ class SpotifyWebAPI
      */
     protected function idToUri($ids)
     {
-        $ids = (array) $ids;
+        $ids = array_values((array) $ids);
 
         for ($i = 0; $i < count($ids); $i++) {
             if (strpos($ids[$i], 'spotify:track:') !== false) {


### PR DESCRIPTION
As the track limit is 100 chunking is needed so array_values just
resets the keys if ever they do not start from 0 e.g. 100+

Could be done app side however this is a bit cleaner, minor change but caused some confusion hunting it down.