### PR TITLE
Add parameter to prevent Request throwing exceptions

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -22,7 +22,7 @@ class Request
      */
     protected function parseBody($body, $status)
     {
-        if (($status >= 200 && $status <= 299) || !$this->throwExceptions)  {
+        if (($status >= 200 && $status <= 299) || !$this->throwExceptions) {
             return json_decode($body, $this->returnAssoc);
         }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -3,6 +3,8 @@ namespace SpotifyWebAPI;
 
 class Request
 {
+    protected $throwExceptions = false;
+
     protected $returnAssoc = false;
 
     const ACCOUNT_URL = 'https://accounts.spotify.com';
@@ -20,7 +22,7 @@ class Request
      */
     protected function parseBody($body, $status)
     {
-        if ($status >= 200 && $status <= 299) {
+        if (($status >= 200 && $status <= 299) || !$this->throwExceptions)  {
             return json_decode($body, $this->returnAssoc);
         }
 
@@ -208,5 +210,16 @@ class Request
     public function setReturnAssoc($returnAssoc)
     {
         $this->returnAssoc = $returnAssoc;
+    }
+
+    /**
+     * @param bool $throwExceptions
+     * @return \SpotifyWebAPI\Request
+     */
+    public function setThrowExceptions($throwExceptions)
+    {
+        $this->throwExceptions = $throwExceptions;
+
+        return $this;
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -3,7 +3,7 @@ namespace SpotifyWebAPI;
 
 class Request
 {
-    protected $throwExceptions = false;
+    protected $throwExceptions = true;
 
     protected $returnAssoc = false;
 

--- a/src/SpotifyWebAPI.php
+++ b/src/SpotifyWebAPI.php
@@ -1195,6 +1195,19 @@ class SpotifyWebAPI
     }
 
     /**
+     * Set the paramater to decide if Request should throw an exception when it encounters an invalid response
+     *
+     * @param bool $throwExceptions
+     *
+     * @return void
+     */
+    public function setThrowExceptions($throwExceptions)
+    {
+        $this->request->setThrowExceptions($throwExceptions);
+    }
+
+
+    /**
      * Remove the current user as a follower of one or more artists or other Spotify users.
      * Requires a valid access token.
      * https://developer.spotify.com/web-api/unfollow-artists-users/

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -149,4 +149,14 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $response = $request->send('GET', 'https://api.spotify.com/v1/albums/7u6zL7kqpgLPISZYXNTgYk');
         $this->assertArrayHasKey('id', $response['body']);
     }
+
+    public function testSetThrowExceptions()
+    {
+        $request = new SpotifyWebAPI\Request();
+
+        // The actual functionality of this cannot be unit tested in the current implementation
+        $result = $request->setThrowExceptions(true);
+
+        $this->assertEquals($request, $result);
+    }
 }

--- a/tests/SpotifyWebAPITest.php
+++ b/tests/SpotifyWebAPITest.php
@@ -1712,4 +1712,12 @@ class SpotifyWebAPITest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($response[0]);
     }
+
+    public function testSetThrowExceptions()
+    {
+        $result = (new SpotifyWebAPI\SpotifyWebAPI())
+            ->setThrowExceptions(true);
+
+        $this->assertNull($result);
+    }
 }


### PR DESCRIPTION
in the current implementation, a "rate limit exceeded" response results in Request throwing an exception.  This means that SpotifyWebAPI::$lastResponse does not get set, so there is no way to access the Retry-After header.

Simply not throwing the exception means that the response gets returned, and the caller can check the status and decide if this should be an exception or not.