### PR TITLE
Add a Request::getLastResponse() method

### DIFF
--- a/docs/examples/error-handling.md
+++ b/docs/examples/error-handling.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Error handling
+---
+
+Whenever the API returns a error of some sort, a [PHP Exception](http://php.net/manual/en/language.exceptions.php) will be thrown.
+The `message` property will be set to the error message returned by the Spotify API and the `code` property will be set to the HTTP status code returned by the Spotify API.
+
+## Handling errors
+
+    <?php
+    try {
+        $track = $api->getTrack('non-existing-track');
+    } catch (Exception $e) {
+        echo 'Spotify API Error: ' . $e->getCode(); // Will be 404
+    }
+
+### Handling rate limit errors
+
+    <?php
+    try {
+        $track = $api->getTrack('7EjyzZcbLxW7PaaLua9Ksb');
+    } catch (Exception $e) {
+        if ($e->getCode() == 429) { // 429 is Too Many Requests
+            $lastResponse = $api->getRequest()->getLastResponse(); // Note getRequest() since $api->getLastResponse() won't be set
+
+            $retryAfter = $lastResponse['headers']['Retry-After']; // Number of seconds to wait before sending another request
+        } else {
+            // Some other kind of error
+        }
+    }
+
+Read more about the exact mechanics of rate limiting in the [Spotify API docs](https://developer.spotify.com/web-api/user-guide/#rate-limiting).

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -5,6 +5,7 @@ title: Examples
 
 *Note: All examples assume the use of Composer or a autoloader.*
 
+* [Error handling](error-handling.html)
 * [Following artists, playlists and users](following.html)
 * [Getting artists, albums or tracks](getting-objects.html)
 * [Getting Spotify featured content](getting-spotify-content.html)

--- a/src/Request.php
+++ b/src/Request.php
@@ -3,10 +3,25 @@ namespace SpotifyWebAPI;
 
 class Request
 {
+    protected $lastResponse = [];
     protected $returnAssoc = false;
 
     const ACCOUNT_URL = 'https://accounts.spotify.com';
     const API_URL = 'https://api.spotify.com';
+
+    /**
+     * Get the latest full response from the Spotify API.
+     *
+     * @return array Response data.
+     * - array|object body The response body. Type is controlled by Request::setReturnAssoc().
+     * - array headers Response headers.
+     * - int status HTTP status code.
+     * - string url The requested URL.
+     */
+    public function getLastResponse()
+    {
+        return $this->lastResponse;
+    }
 
     /**
      * Parse the response body and handle API errors.
@@ -20,8 +35,10 @@ class Request
      */
     protected function parseBody($body, $status)
     {
+        $this->lastResponse['body'] = json_decode($body, $this->returnAssoc);
+
         if ($status >= 200 && $status <= 299) {
-            return json_decode($body, $this->returnAssoc);
+            return $this->lastResponse['body'];
         }
 
         $body = json_decode($body);
@@ -128,7 +145,10 @@ class Request
      */
     public function send($method, $url, $parameters = [], $headers = [])
     {
-        // Sometimes a JSON object is passed
+        // Reset any old responses
+        $this->lastResponse = [];
+
+        // Sometimes a stringified JSON object is passed
         if (is_array($parameters) || is_object($parameters)) {
             $parameters = http_build_query($parameters);
         }
@@ -186,16 +206,19 @@ class Request
 
         $status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $headers = $this->parseHeaders($headers);
-        $body = $this->parseBody($body, $status);
 
-        curl_close($ch);
-
-        return [
-            'body' => $body,
+        $this->lastResponse = [
             'headers' => $headers,
             'status' => $status,
             'url' => $url,
         ];
+
+        // Run this here since we might throw
+        $body = $this->parseBody($body, $status);
+
+        curl_close($ch);
+
+        return $this->lastResponse;
     }
 
     /**

--- a/src/SpotifyWebAPI.php
+++ b/src/SpotifyWebAPI.php
@@ -835,6 +835,16 @@ class SpotifyWebAPI
     }
 
     /**
+     * Get the Request object in use.
+     *
+     * @return Request The Request object in use.
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
      * Get a track.
      * https://developer.spotify.com/web-api/get-track/
      *

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -51,6 +51,15 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $response = $this->request->account('POST', '/api/token', $parameters, $headers);
     }
 
+    public function testGetLastResponse()
+    {
+        $this->request->send('GET', 'https://api.spotify.com/v1/albums/7u6zL7kqpgLPISZYXNTgYk');
+
+        $response = $this->request->getLastResponse();
+
+        $this->assertObjectHasAttribute('id', $response['body']);
+    }
+
     public function testSend()
     {
         $response = $this->request->send('GET', 'https://api.spotify.com/v1/albums/7u6zL7kqpgLPISZYXNTgYk');

--- a/tests/SpotifyWebAPITest.php
+++ b/tests/SpotifyWebAPITest.php
@@ -1101,6 +1101,13 @@ class SpotifyWebAPITest extends PHPUnit_Framework_TestCase
         $this->assertTrue($api->getReturnAssoc());
     }
 
+    public function testGetRequest()
+    {
+        $api = new SpotifyWebAPI\SpotifyWebAPI();
+
+        $this->assertInstanceOf(SpotifyWebAPI\Request::class, $api->getRequest());
+    }
+
     public function testGetTrack()
     {
         $options = [


### PR DESCRIPTION
Since `SpotifyWebAPI::getLastResponse()` isn't available when exceptions are thrown (as noted in #60) I've added a new `getLastResponse()` method to `Request` as well which will always be populated will the full response.