### PR TITLE
Convert Spotify URIs to Spotify IDs for addMyTracks

### DIFF
--- a/src/SpotifyWebAPI.php
+++ b/src/SpotifyWebAPI.php
@@ -58,6 +58,22 @@ class SpotifyWebAPI
     }
 
     /**
+     * Convert Spotify URIs to Spotify object IDs
+     *
+     * @param array|string $uriIds URI(s) to convert.
+     *
+     * @return array|string Spotify ID(s).
+     */
+    protected function uriToId($uriIds)
+    {
+        $uriIds = array_map(function ($id) {
+            return str_replace('spotify:track:', '', $id);
+        }, (array) $uriIds);
+
+        return (count($uriIds) == 1) ? $uriIds[0] : $uriIds;
+    }
+
+    /**
      * Add albums to the current user's Spotify library.
      * Requires a valid access token.
      * https://developer.spotify.com/web-api/save-albums-user/
@@ -91,6 +107,7 @@ class SpotifyWebAPI
      */
     public function addMyTracks($tracks)
     {
+        $tracks = $this->uriToId($tracks);
         $tracks = json_encode((array) $tracks);
 
         $headers = $this->authHeaders();

--- a/tests/SpotifyWebAPITest.php
+++ b/tests/SpotifyWebAPITest.php
@@ -60,9 +60,16 @@ class SpotifyWebAPITest extends PHPUnit_Framework_TestCase
         $tracks = [
             '1id6H6vcwSB9GGv9NXh5cl',
             '3mqRLlD9j92BBv1ueFhJ1l',
+            'spotify:track:1id6H6vcwSB9GGv9NXh5cl',
         ];
 
-        $expected = json_encode($tracks);
+        $expectedTracks = [
+            '1id6H6vcwSB9GGv9NXh5cl',
+            '3mqRLlD9j92BBv1ueFhJ1l',
+            '1id6H6vcwSB9GGv9NXh5cl',
+        ];
+
+        $expected = json_encode($expectedTracks);
 
         $headers = [
             'Authorization' => 'Bearer ' . $this->accessToken,


### PR DESCRIPTION
The method addMyTracks didn't accept Spotify URI's as parameters (since the Spotify API expects only id's). Added a method that converts URIs to IDs. It strips the 'spotify:track:' value from the URIs.