### PR TITLE
Took out WebApi object in the examples

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,8 +79,6 @@ $session = new SpotifyWebAPI\Session(
     'REDIRECT_URI'
 );
 
-$api = new SpotifyWebAPI\SpotifyWebAPI();
-
 // Request a access token using the code from Spotify
 $session->requestAccessToken($_GET['code']);
 
@@ -105,8 +103,6 @@ $session = new SpotifyWebAPI\Session(
     'CLIENT_SECRET',
     'REDIRECT_URI'
 );
-
-$api = new SpotifyWebAPI\SpotifyWebAPI();
 
 $session->requestCredentialsToken();
 $accessToken = $session->getAccessToken();


### PR DESCRIPTION
I don't understand why these two chunks of code have a SpotifyWebApi object being created in them. They're not used in the code snippets. Maybe if the example added an example of setting the access token in the same script...? (But this is already shown in $api-setAccessToken($accessToken)