### PR TITLE
Bugfix, send empty body when no options are passed in for the me/play…

### DIFF
--- a/src/SpotifyWebAPI.php
+++ b/src/SpotifyWebAPI.php
@@ -1321,7 +1321,7 @@ class SpotifyWebAPI
      */
     public function play($deviceId = '', $options = [])
     {
-        $options = json_encode((object) $options);
+        $options = (!empty($options)) ? json_encode((object) $options) : $options;
 
         $headers = $this->authHeaders();
         $headers['Content-Type'] = 'application/json';


### PR DESCRIPTION
…er/play endpoint.

Hi,

I came a across a bug where the player won't resume anymore. This was cost because of the body it was sending. When you just want to resume the player you must send a empty body, which was not the case since you converted the array to a json object.

First I wanted to solve this by making `$options` standard null but I saw you handled other endpoints with no body with a empty array.