### PR TITLE
Ignore "200 Connection established" header group that comes from proxy

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -209,6 +209,11 @@ class Request
 
         list($headers, $body) = explode("\r\n\r\n", $response, 2);
 
+        // Skip the first set of headers for proxied requests
+        if (preg_match('/^HTTP\/1\.\d 200 Connection established$/', $headers) === 1) {
+            list($headers, $body) = explode("\r\n\r\n", $body, 2);
+        }
+
         $status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $headers = $this->parseHeaders($headers);
 


### PR DESCRIPTION
When requests are proxied through an HTTP proxy, the response come back with two groups of headers as below.

This pull request checks for this and strips it before continuing the processing in the Request class.

```
HTTP/1.1 200 Connection established

HTTP/1.1 200 OK
...
```