### PR TITLE
refreshAccessToken no param, setter doco needed

### DIFF
--- a/docs/examples/access-token-with-authorization-code-flow.md
+++ b/docs/examples/access-token-with-authorization-code-flow.md
@@ -90,8 +90,13 @@ When the access token has expired, request a new one using the refresh token:
 ```php
 // Fetch the refresh token from somewhere. A database for example.
 
-$session->refreshAccessToken($refreshToken);
+// Then use the setter (only if requestAccessToken() not called on same object already) 
+$session->setRefreshToken($refreshToken);
 
+// Call to refresh (uses clientId, clientSecret and refreshToken set earlier)
+$session->refreshAccessToken();
+
+// Retrieve the updated access token
 $accessToken = $session->getAccessToken();
 
 // Set our new access token on the API wrapper and continue to use the API as usual


### PR DESCRIPTION
Found a mismatch with current Session.php and doco regarding refreshing access tokens, that method has no param, so you need to call seperate setter if not in same execution flow as retrieving the access token itself.