### PR TITLE
Better support for refresh tokens

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -153,7 +153,7 @@ class Session
             $this->accessToken = $response->access_token;
             $this->expirationTime = time() + $response->expires_in;
             $this->scope = $response->scope ?? $this->scope;
-            $this->refreshToken = $response->refresh_token ?? $this->refreshToken;
+            $this->refreshToken = $response->refresh_token ?? $this->refreshToken ?? $refreshToken;
 
             return true;
         }

--- a/src/Session.php
+++ b/src/Session.php
@@ -259,4 +259,16 @@ class Session
     {
         $this->redirectUri = $redirectUri;
     }
+
+    /**
+     * Set the session's refresh token.
+     *
+     * @param string $refreshToken The refresh token.
+     *
+     * @return void
+     */
+    public function setRefreshToken($refreshToken)
+    {
+        $this->refreshToken = $refreshToken;
+    }
 }


### PR DESCRIPTION
Currently if you call a refresh like this:

```
    $session = new Session(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI);
    $session->setRefreshToken($row['refresh_token']);
    $session->refreshAccessToken($row['refresh_token']);

    $access_token = $session->getAccessToken();
    $refresh_token = $session->getRefreshToken();
    $expiry = $session->getTokenExpiration();
```

You could end up with an error if the refresh token in the class isn't updated. This fixes this by setting the refresh token to the refresh token passed through if it hasn't been updated or isn't already set.

Also adds a setter for the refresh token which can be useful or an alternative to the above requiring an extra line of code before calling the `refreshAccessToken` method.