### PR TITLE
Added Authentication specific exception

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -19,6 +19,7 @@ class Request
      * @param int $status The HTTP status code, used to see if additional error handling is needed.
      *
      * @throws SpotifyWebAPIException
+     * @throws SpotifyWebAPIAuthException
      *
      * @return array|object The parsed response body. Type is controlled by `Request::setReturnType()`.
      */
@@ -38,7 +39,7 @@ class Request
             throw new SpotifyWebAPIException($error->message, $error->status);
         } elseif (isset($body->error_description)) {
             // Auth call error
-            throw new SpotifyWebAPIException($body->error_description, $status);
+            throw new SpotifyWebAPIAuthException($body->error_description, $status);
         } else {
             // Something went really wrong
             throw new SpotifyWebAPIException('An unknown error occurred.', $status);
@@ -77,6 +78,9 @@ class Request
      * @param array $parameters Optional. Query string parameters or HTTP body, depending on $method.
      * @param array $headers Optional. HTTP headers.
      *
+     * @throws SpotifyWebAPIException
+     * @throws SpotifyWebAPIAuthException
+     *
      * @return array Response data.
      * - array|object body The response body. Type is controlled by `Request::setReturnType()`.
      * - string headers Response headers.
@@ -95,6 +99,9 @@ class Request
      * @param string $uri The URI to request.
      * @param array $parameters Optional. Query string parameters or HTTP body, depending on $method.
      * @param array $headers Optional. HTTP headers.
+     *
+     * @throws SpotifyWebAPIException
+     * @throws SpotifyWebAPIAuthException
      *
      * @return array Response data.
      * - array|object body The response body. Type is controlled by `Request::setReturnType()`.
@@ -141,6 +148,7 @@ class Request
      * @param array $headers Optional. HTTP headers.
      *
      * @throws SpotifyWebAPIException
+     * @throws SpotifyWebAPIAuthException
      *
      * @return array Response data.
      * - array|object body The response body. Type is controlled by `Request::setReturnType()`.

--- a/src/SpotifyWebAPIAuthException.php
+++ b/src/SpotifyWebAPIAuthException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SpotifyWebAPI;
+
+class SpotifyWebAPIAuthException extends SpotifyWebAPIException
+{
+    // extends from SpotifyWebApiException for backwards compatibility
+}

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -87,7 +87,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
             'Authorization' => 'Basic ' . $payload,
         ];
 
-        $this->expectException(SpotifyWebAPI\SpotifyWebAPIException::class);
+        $this->expectException(SpotifyWebAPI\SpotifyWebAPIAuthException::class);
 
         $request = new SpotifyWebAPI\Request();
         $response = $request->account('POST', '/api/token', $parameters, $headers);


### PR DESCRIPTION
I would like to be able to catch authentication specific exceptions, so I can automate the refreshing of tokens more easily. I know I have the time when the access token needs to be refreshed, but even then sometimes the token is invalidated earlier, and I get the exception.

Also updated the test so it reflects this change, while making it backwards compatible by extending the original `SpotifyWebAPIException`. 

Please consider a merge. Thanks for the great library!