### PR TITLE
Added helper functions to Exceptions for easier handling.

### DIFF
--- a/src/SpotifyWebAPIAuthException.php
+++ b/src/SpotifyWebAPIAuthException.php
@@ -5,9 +5,9 @@ namespace SpotifyWebAPI;
 class SpotifyWebAPIAuthException extends SpotifyWebAPIException
 {
     // extends from SpotifyWebApiException for backwards compatibility
-    const INVALID_CLIENT = "Invalid client";
-    const INVALID_CLIENT_SECRET = "Invalid client secret";
-    const INVALID_REFRESH_TOKEN = "Invalid refresh token";
+    const INVALID_CLIENT = 'Invalid client';
+    const INVALID_CLIENT_SECRET = 'Invalid client secret';
+    const INVALID_REFRESH_TOKEN = 'Invalid refresh token';
 
     /**
      * Returns if the exception was thrown because of invalid credentials.

--- a/src/SpotifyWebAPIAuthException.php
+++ b/src/SpotifyWebAPIAuthException.php
@@ -5,4 +5,28 @@ namespace SpotifyWebAPI;
 class SpotifyWebAPIAuthException extends SpotifyWebAPIException
 {
     // extends from SpotifyWebApiException for backwards compatibility
+    const INVALID_CLIENT = "Invalid client";
+    const INVALID_CLIENT_SECRET = "Invalid client secret";
+    const INVALID_REFRESH_TOKEN = "Invalid refresh token";
+
+    /**
+     * Returns if the exception was thrown because of invalid credentials.
+     * @return bool
+     */
+    public function hasInvalidCredentials()
+    {
+        return in_array($this->getMessage(), [
+            self::INVALID_CLIENT,
+            self::INVALID_CLIENT_SECRET,
+        ]);
+    }
+
+    /**
+     * Returns if the exception was thrown because of invalid refresh token.
+     * @return bool
+     */
+    public function hasInvalidRefreshToken()
+    {
+        return $this->getMessage() === self::INVALID_REFRESH_TOKEN;
+    }
 }

--- a/src/SpotifyWebAPIException.php
+++ b/src/SpotifyWebAPIException.php
@@ -3,7 +3,7 @@ namespace SpotifyWebAPI;
 
 class SpotifyWebAPIException extends \Exception
 {
-    const TOKEN_EXPIRED = "The access token expired";
+    const TOKEN_EXPIRED = 'The access token expired';
 
     /**
      * Returns if the exception was thrown because of an expired token.

--- a/src/SpotifyWebAPIException.php
+++ b/src/SpotifyWebAPIException.php
@@ -3,5 +3,14 @@ namespace SpotifyWebAPI;
 
 class SpotifyWebAPIException extends \Exception
 {
-    // dummy
+    const TOKEN_EXPIRED = "The access token expired";
+
+    /**
+     * Returns if the exception was thrown because of an expired token.
+     * @return bool
+     */
+    public function hasExpiredToken()
+    {
+        return $this->getMessage() === self::TOKEN_EXPIRED;
+    }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -88,9 +88,14 @@ class RequestTest extends PHPUnit\Framework\TestCase
         ];
 
         $this->expectException(SpotifyWebAPI\SpotifyWebAPIAuthException::class);
-
         $request = new SpotifyWebAPI\Request();
-        $response = $request->account('POST', '/api/token', $parameters, $headers);
+        try {
+            $response = $request->account('POST', '/api/token', $parameters, $headers);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(SpotifyWebAPI\SpotifyWebAPIAuthException::class, $e);
+            $this->assertTrue($e->hasInvalidCredentials());
+            throw $e; // throw again for last test
+        }
     }
 
     public function testGetLastResponse()

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1,4 +1,5 @@
 <?php
+
 class RequestTest extends PHPUnit\Framework\TestCase
 {
     private function setupStub($expectedMethod, $expectedUri, $expectedParameters, $expectedHeaders, $expectedReturn)
@@ -7,15 +8,20 @@ class RequestTest extends PHPUnit\Framework\TestCase
                 ->setMethods(['send'])
                 ->getMock();
 
-        $stub->expects($this->once())
+        $invocation = $stub->expects($this->once())
                  ->method('send')
                  ->with(
                      $this->equalTo($expectedMethod),
                      $this->equalTo($expectedUri),
                      $this->equalTo($expectedParameters),
                      $this->equalTo($expectedHeaders)
-                 )
-                ->willReturn($expectedReturn);
+                 );
+
+        if ($expectedReturn instanceof Exception) {
+            $invocation->willThrowException($expectedReturn);
+        } else {
+            $invocation->willReturn($expectedReturn);
+        }
 
         return $stub;
     }
@@ -95,6 +101,69 @@ class RequestTest extends PHPUnit\Framework\TestCase
             $this->assertInstanceOf(SpotifyWebAPI\SpotifyWebAPIAuthException::class, $e);
             $this->assertTrue($e->hasInvalidCredentials());
             throw $e; // throw again for last test
+        }
+    }
+
+    public function testExpiredToken()
+    {
+        $headers = [
+            'Authorization' => 'Bearer Expired token',
+        ];
+
+        $return = new SpotifyWebAPI\SpotifyWebAPIException('The access token expired', 401);
+
+        $request = $this->setupStub(
+            'GET',
+            'https://api.spotify.com/v1/tracks/2TpxZ7JUBn3uw46aR7qd6V',
+            [],
+            $headers,
+            $return
+        );
+
+        $this->expectException(SpotifyWebAPI\SpotifyWebAPIException::class);
+
+        try {
+            $response = $request->api('GET', '/v1/tracks/2TpxZ7JUBn3uw46aR7qd6V', [], $headers);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(SpotifyWebAPI\SpotifyWebAPIException::class, $e);
+            $this->assertTrue($e->hasExpiredToken());
+            throw $e;
+        }
+    }
+
+    public function testInvalidRefreshToken()
+    {
+        $clientID = 'VALID_ID';
+        $clientSecret = 'VALID_ID';
+        $payload = base64_encode($clientID . ':' . $clientSecret);
+
+        $parameters = [
+            'grant_type' => 'refresh_token',
+            'refresh_token' => 'Invalid refresh token',
+        ];
+
+        $headers = [
+            'Authorization' => 'Basic ' . $payload,
+        ];
+
+        $return = new SpotifyWebAPI\SpotifyWebAPIAuthException('Invalid refresh token', 400);
+
+        $request = $this->setupStub(
+            'POST',
+            'https://accounts.spotify.com/api/token',
+            $parameters,
+            $headers,
+            $return
+        );
+
+        $this->expectException(SpotifyWebAPI\SpotifyWebAPIAuthException::class);
+
+        try {
+            $response = $request->account('POST', '/api/token', $parameters, $headers);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(SpotifyWebAPI\SpotifyWebAPIAuthException::class, $e);
+            $this->assertTrue($e->hasInvalidRefreshToken());
+            throw $e;
         }
     }
 


### PR DESCRIPTION
To help the ease of implementation of #137 I've added some helper functions to the exceptions themself. 

It's split into the two exceptions, because they both are responsible for a different part. When requesting some info using an expired access token, the general exception is triggered. For the initial authorization flow the `SpotifyWebAPIAuthException` is thrown. 

@jwilsson It was not so easy to get these error messages. I've had to generate some keys to check them later. As a result I'm not sure how we should put this under tests. If you have any ideas let me know, or be my guest 😄. 

Edit: So I've tried adding some tests. I did need to change your `setupStub` function to also be able to throw exceptions as a result. If you have issues with them, please let me know. I'd love to learn some new tricks. 