### PR TITLE
Added method getReason() to SpotifyWebAPIException

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -36,7 +36,13 @@ class Request
 
         if (isset($error->message) && isset($error->status)) {
             // API call error
-            throw new SpotifyWebAPIException($error->message, $error->status);
+            $exception = new SpotifyWebAPIException($error->message, $error->status);
+
+            if (isset($error->reason)) {
+                $exception->setReason($error->reason);
+            }
+
+            throw $exception;
         } elseif (isset($body->error_description)) {
             // Auth call error
             throw new SpotifyWebAPIAuthException($body->error_description, $status);

--- a/src/SpotifyWebAPIException.php
+++ b/src/SpotifyWebAPIException.php
@@ -6,11 +6,38 @@ class SpotifyWebAPIException extends \Exception
     const TOKEN_EXPIRED = 'The access token expired';
 
     /**
+     * The reason string from the requests error object
+     * @var string
+     */
+    private $reason;
+
+    /**
+     * Returns the reason string from the requests error object
+     *
+     * @see https://developer.spotify.com/documentation/web-api/reference/object-model/#player-error-reasons
+     *
+     * @return string
+     */
+    public function getReason()
+    {
+        return $this->reason;
+    }
+
+    /**
      * Returns if the exception was thrown because of an expired token.
      * @return bool
      */
     public function hasExpiredToken()
     {
         return $this->getMessage() === self::TOKEN_EXPIRED;
+    }
+
+    /**
+     * Set the reason string
+     * @param string $reason
+     */
+    public function setReason($reason)
+    {
+        $this->reason = $reason;
     }
 }

--- a/tests/SpotifyWebAPITest.php
+++ b/tests/SpotifyWebAPITest.php
@@ -2079,6 +2079,15 @@ class SpotifyWebAPITest extends PHPUnit\Framework\TestCase
         $this->assertTrue($response);
     }
 
+    public function testSetReasonOnSpotifyWebAPIException()
+    {
+        $expectedReason = 'NO_ACTIVE_DEVICE';
+
+        $exception = new \SpotifyWebAPI\SpotifyWebAPIException();
+        $exception->setReason($expectedReason);
+        $this->assertEquals($expectedReason, $exception->getReason());
+    }
+
     public function testSetReturnType()
     {
         $stub = $this->getMockBuilder('Request')


### PR DESCRIPTION
When working with the Player API it's really handy to have the [error reason string](https://developer.spotify.com/documentation/web-api/reference/object-model/#player-error-reasons) available.

I've not written much tests in my life, and I'm honestly not sure if this will do. If you want anything changed, just let me know and I will try to have it fixed.