### PR TITLE
Bugfix in deletePlaylistTracks for RETURN_ASSOC

### DIFF
--- a/src/SpotifyWebAPI.php
+++ b/src/SpotifyWebAPI.php
@@ -417,6 +417,8 @@ class SpotifyWebAPI
 
         if (isset($body->snapshot_id)) {
             return $body->snapshot_id;
+        } elseif (isset($body['snapshot_id'])) {
+            return $body['snapshot_id'];
         }
 
         return false;


### PR DESCRIPTION
When i change return type from `Request::RETURN_OBJECT` to `Request::RETURN_ASSOC` .
The `deletePlaylistTracks`-Methods always returns false