### PR TITLE
Endpoint Follow Artists/User JSON Body had wrong format

### DIFF
--- a/src/SpotifyWebAPI.php
+++ b/src/SpotifyWebAPI.php
@@ -537,6 +537,7 @@ class SpotifyWebAPI
         $ids = json_encode([
             'ids' => (array) $ids,
         ]);
+        $ids = str_replace(',', '","', $ids);
 
         $headers = [
             'Content-Type' => 'application/json',


### PR DESCRIPTION
[Endpoint Reference](https://developer.spotify.com/documentation/web-api/reference/#endpoint-follow-artists-users)

When sending the ID's in the body they should be formatted like this: 
`{ids:["74ASZWbe4lXaubB36ztrGX", "08td7MxkoHQkXnWAYD8d6Q"]}`
But they got formatted like this:
`{ids:["74ASZWbe4lXaubB36ztrGX,08td7MxkoHQkXnWAYD8d6Q"]}`

Thanks for providing this Repo, it helped me alot!