### PR TITLE
Add return self on setters

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -252,11 +252,13 @@ class Request
      *
      * @param array|object $options Options to set.
      *
-     * @return void
+     * @return self
      */
     public function setOptions($options)
     {
         $this->options = array_merge($this->options, (array) $options);
+
+        return $this;
     }
 
     /**

--- a/src/Session.php
+++ b/src/Session.php
@@ -299,11 +299,13 @@ class Session
      *
      * @param string $accessToken The access token
      *
-     * @return void
+     * @return self
      */
     public function setAccessToken($accessToken)
     {
         $this->accessToken = $accessToken;
+
+        return $this;
     }
 
     /**
@@ -311,11 +313,13 @@ class Session
      *
      * @param string $clientId The client ID.
      *
-     * @return void
+     * @return self
      */
     public function setClientId($clientId)
     {
         $this->clientId = $clientId;
+
+        return $this;
     }
 
     /**
@@ -323,11 +327,13 @@ class Session
      *
      * @param string $clientSecret The client secret.
      *
-     * @return void
+     * @return self
      */
     public function setClientSecret($clientSecret)
     {
         $this->clientSecret = $clientSecret;
+
+        return $this;
     }
 
     /**
@@ -335,11 +341,13 @@ class Session
      *
      * @param string $redirectUri The redirect URI.
      *
-     * @return void
+     * @return self
      */
     public function setRedirectUri($redirectUri)
     {
         $this->redirectUri = $redirectUri;
+
+        return $this;
     }
 
     /**
@@ -347,10 +355,12 @@ class Session
      *
      * @param string $refreshToken The refresh token.
      *
-     * @return void
+     * @return self
      */
     public function setRefreshToken($refreshToken)
     {
         $this->refreshToken = $refreshToken;
+
+        return $this;
     }
 }

--- a/src/SpotifyWebAPI.php
+++ b/src/SpotifyWebAPI.php
@@ -2029,11 +2029,13 @@ class SpotifyWebAPI
      *
      * @param string $accessToken The access token.
      *
-     * @return void
+     * @return self
      */
     public function setAccessToken($accessToken)
     {
         $this->accessToken = $accessToken;
+
+        return $this;
     }
 
     /**
@@ -2041,11 +2043,13 @@ class SpotifyWebAPI
      *
      * @param array|object $options Options to set.
      *
-     * @return void
+     * @return self
      */
     public function setOptions($options)
     {
         $this->options = array_merge($this->options, (array) $options);
+
+        return $this;
     }
 
     /**
@@ -2053,11 +2057,13 @@ class SpotifyWebAPI
      *
      * @param Session $session The Session object.
      *
-     * @return void
+     * @return self
      */
     public function setSession($session)
     {
         $this->session = $session;
+
+        return $this;
     }
 
     /**

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -304,12 +304,13 @@ class RequestTest extends PHPUnit\Framework\TestCase
     public function testSetOptions()
     {
         $request = new SpotifyWebAPI\Request();
-        $request->setOptions([
+        $returnedValue = $request->setOptions([
             'return_assoc' => true,
         ]);
 
         $response = $request->send('GET', 'https://httpbin.org/get');
 
         $this->assertArrayHasKey('url', $response['body']);
+        $this->assertEquals($request, $returnedValue);
     }
 }

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -366,8 +366,9 @@ class SessionTest extends PHPUnit\Framework\TestCase
         $session = new SpotifyWebAPI\Session($this->clientID, $this->clientSecret, $this->redirectURI);
         $expected = $this->accessToken;
 
-        $session->setAccessToken($expected);
+        $returnedValue = $session->setAccessToken($expected);
 
+        $this->assertEquals($session, $returnedValue);
         $this->assertEquals($expected, $session->getAccessToken());
     }
 
@@ -376,8 +377,9 @@ class SessionTest extends PHPUnit\Framework\TestCase
         $session = new SpotifyWebAPI\Session($this->clientID, $this->clientSecret, $this->redirectURI);
         $expected = $this->clientID;
 
-        $session->setClientId($expected);
+        $returnedValue = $session->setClientId($expected);
 
+        $this->assertEquals($session, $returnedValue);
         $this->assertEquals($expected, $session->getClientId());
     }
 
@@ -386,8 +388,9 @@ class SessionTest extends PHPUnit\Framework\TestCase
         $session = new SpotifyWebAPI\Session($this->clientID, $this->clientSecret, $this->redirectURI);
         $expected = $this->clientSecret;
 
-        $session->setClientSecret($expected);
+        $returnedValue = $session->setClientSecret($expected);
 
+        $this->assertEquals($session, $returnedValue);
         $this->assertEquals($expected, $session->getClientSecret());
     }
 
@@ -396,8 +399,9 @@ class SessionTest extends PHPUnit\Framework\TestCase
         $session = new SpotifyWebAPI\Session($this->clientID, $this->clientSecret, $this->redirectURI);
         $expected = $this->redirectURI;
 
-        $session->setRedirectUri($expected);
+        $returnedValue = $session->setRedirectUri($expected);
 
+        $this->assertEquals($session, $returnedValue);
         $this->assertEquals($expected, $session->getRedirectUri());
     }
 
@@ -406,8 +410,9 @@ class SessionTest extends PHPUnit\Framework\TestCase
         $session = new SpotifyWebAPI\Session($this->clientID, $this->clientSecret, $this->redirectURI);
         $expected = $this->refreshToken;
 
-        $session->setRefreshToken($expected);
+        $returnedValue = $session->setRefreshToken($expected);
 
+        $this->assertEquals($session, $returnedValue);
         $this->assertEquals($expected, $session->getRefreshToken());
     }
 }

--- a/tests/SpotifyWebAPITest.php
+++ b/tests/SpotifyWebAPITest.php
@@ -2260,4 +2260,25 @@ class SpotifyWebAPITest extends PHPUnit\Framework\TestCase
 
         $this->assertTrue($response[0]);
     }
+
+    public function testSetAccessToken() {
+        $api = new SpotifyWebAPI\SpotifyWebAPI();
+        $returnedValue = $api->setAccessToken($this->accessToken);
+
+        $this->assertEquals($api, $returnedValue);        
+    }
+
+    public function testSetOptions() {
+        $api = new SpotifyWebAPI\SpotifyWebAPI();
+        $returnedValue = $api->setOptions([]);
+
+        $this->assertEquals($api, $returnedValue);        
+    }
+
+    public function testSetSession() {
+        $api = new SpotifyWebAPI\SpotifyWebAPI();
+        $returnedValue = $api->setSession($this->setupSessionStub());
+
+        $this->assertEquals($api, $returnedValue);        
+    }
 }


### PR DESCRIPTION
Hi,

First of all, thanks for your work, this package is perfect.
The reason of this PR is to add a little improvement, especially usefull when using the api like following

```
$api = new SpotifyWebAPI\SpotifyWebAPI();
$api->setAccessToken(session()->get('access_token'));
$user = $api->me();
```

It will now be possible to chain the setters such as 

```
$me = (new SpotifyWebAPI\SpotifyWebAPI())
    ->setAccessToken(session()->get('access_token'))
    ->me();
```

Since I'm using this package in my project, i faced this and wanted to contribute on my own to this project.
I also added the tests to cover this expectation. I hope everything will be fine to you.

PS: I also i noticed a deprecation on `assertObjectHasAttribute` that will be remove in PhpUnit 10. I didn't want to mix up the PR so feel free to say if you want i can mass search and replace the usages 👍 (it will become `assertObjectHasProperty`)