### PR TITLE
convert self to static in Request.php

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -114,7 +114,7 @@ class Request
      */
     public function account(string $method, string $uri, string|array $parameters = [], array $headers = []): array
     {
-        return $this->send($method, self::ACCOUNT_URL . $uri, $parameters, $headers);
+        return $this->send($method, static::ACCOUNT_URL . $uri, $parameters, $headers);
     }
 
     /**
@@ -136,7 +136,7 @@ class Request
      */
     public function api(string $method, string $uri, string|array $parameters = [], array $headers = []): array
     {
-        return $this->send($method, self::API_URL . $uri, $parameters, $headers);
+        return $this->send($method, static::API_URL . $uri, $parameters, $headers);
     }
 
     /**


### PR DESCRIPTION
Ok here is the problem.
In some regions spotify blocks the request to bypass it we need to use a proxy. 
And for that, we need to change the `ACCOUNT_URL` and `API_URL`.
I've extended the `Request` class and changed those constants. I also passed my custom `Request` class to the web API.
But since you used `self::`, it's not inheritance-aware. By using `static::`, it will be inheritance-aware, and we can change those constants.