### PR TITLE
Fix trailing slash before GET query parameters

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -228,7 +228,7 @@ class Request
                 $options[CURLOPT_CUSTOMREQUEST] = $method;
 
                 if ($parameters) {
-                    $options[CURLOPT_URL] .= '/?' . $parameters;
+                    $options[CURLOPT_URL] .= '?' . $parameters;
                 }
 
                 break;

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -229,7 +229,7 @@ class RequestTest extends TestCase
         $this->setupFunctionMock('curl_setopt_array')->willReturnCallback(
             function (\CurlHandle $ch, array $options) {
                 $this->assertEquals('GET', $options[CURLOPT_CUSTOMREQUEST]);
-                $this->assertEquals('https://www.example.com/?foo=bar', $options[CURLOPT_URL]);
+                $this->assertEquals('https://www.example.com?foo=bar', $options[CURLOPT_URL]);
             },
         );
 


### PR DESCRIPTION
## Summary

GET requests with query parameters currently append `/?` to the endpoint URL.

For example:

```text
https://api.spotify.com/v1/me/player/recently-played/?limit=10
```

Spotify returns a `404` response for this URL, while the canonical URL without the trailing slash succeeds:

```text
https://api.spotify.com/v1/me/player/recently-played?limit=10
```

## Changes

- Change GET query string construction from `/?` to `?`.
- Update the corresponding test to ensure query parameters do not modify the endpoint path.

## Verification

Confirmed that:

```php
$api->getMyRecentTracks([
    'limit' => 10,
]);
```

returns a `404` response before this change and returns the expected recently played tracks after the change.

- [x] `composer test`
- [x] `composer lint`